### PR TITLE
Added Routing options to App-Routing, Switched HttpClientModule in imports to provideHttpClient method in the providers

### DIFF
--- a/modelcabinet.client/src/app/app-routing.module.ts
+++ b/modelcabinet.client/src/app/app-routing.module.ts
@@ -1,7 +1,14 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-const routes: Routes = [];
+// TODO: Change Names to actual Module Names
+const routes: Routes = [
+  { path: '', pathMatch: "full", component: LandingPageComponent },
+  { path: 'Projects', component: ProjectListPageComponent },
+  { path: 'Projects/:id', component: ProjectPageComponent },
+  { path: 'Help', component: HelpPageComponent },
+  { path: 'User', component: UserPageComponent }
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/modelcabinet.client/src/app/app.module.ts
+++ b/modelcabinet.client/src/app/app.module.ts
@@ -1,9 +1,9 @@
-import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { provideHttpClient } from '@angular/common/http';
 
 @NgModule({
   declarations: [
@@ -11,10 +11,9 @@ import { AppComponent } from './app.component';
   ],
   imports: [
     BrowserModule,
-    HttpClientModule,
     AppRoutingModule
   ],
-  providers: [],
+  providers: [provideHttpClient()], // Using this method rather than the module as the module is labeled as depricated
   bootstrap: [AppComponent]
 })
 export class AppModule { }


### PR DESCRIPTION
Added 5 routing options:
 - ''
 - 'Projects'
 - 'Projects/:id'
 - 'Help'
 - 'User'

Currently the front end doesn't compile on the front end, but that is due to the modules not currently existing.

The HttpClientModule is labeled as deprecated, so I switched it over to provideHttpClient method that is recommended for the newer Angular Versions.