### PR TITLE
feat: basic logic for project creation and editing form

### DIFF
--- a/modelcabinet.client/src/app/app.module.ts
+++ b/modelcabinet.client/src/app/app.module.ts
@@ -12,6 +12,10 @@ import { ProjectPageComponent } from './projects/project-page/project-page.compo
 import { AboutProjectComponent } from './about-project/about-project.component';
 import { ChangelogComponent } from './changelog/changelog.component';
 
+// Project Edit Component
+import { ProjectEditComponent } from './projects/project-edit/project-edit.component';
+import { ReactiveFormsModule } from '@angular/forms';
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -22,10 +26,12 @@ import { ChangelogComponent } from './changelog/changelog.component';
     NavBarComponent,
     AboutProjectComponent,
     ChangelogComponent,
+    ProjectEditComponent,
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule
+    AppRoutingModule,
+    ReactiveFormsModule // For Project Edit Component
   ],
   providers: [provideHttpClient()], // Using this method rather than the module as the module is labeled as depricated
   bootstrap: [AppComponent]

--- a/modelcabinet.client/src/app/data.service.ts
+++ b/modelcabinet.client/src/app/data.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, Observable, tap } from "rxjs";
 import { Project } from "./Models/project";
 import { Asset } from "./Models/asset";
 
@@ -54,6 +54,20 @@ export class DataService {
       this.project$.next(data);
       // this.assets$.next(data.asset.&values);
     });
+  }
+
+  // https://www.bacancytechnology.com/qanda/angular/difference-between-behaviorsubject-and-observable
+  // Modify this if needed, observables should be fine since this is being pulled at certain times and we don't
+  // need to grab the most up to date state
+
+  // chain together what's returned to what's gonna perform the size effects
+
+  // https://www.learnrxjs.io/learn-rxjs/operators/utility/do
+  // not modifying data so it'll be an exact copy of the original
+  getProjectInfoById(id: number): Observable<Project> {
+    return this.http.get<Project>(`/api/Projects/${id}`).pipe(
+      tap(data => this.project$.next(data))
+    );
   }
 
   updateProjectById(id: number, project: Project) {

--- a/modelcabinet.client/src/app/projects/project-edit/project-edit.component.html
+++ b/modelcabinet.client/src/app/projects/project-edit/project-edit.component.html
@@ -1,0 +1,10 @@
+<!-- modify this depending on whether project page component acts as a template for how the edit page will look?-->
+<h2>{{isEditing ? 'Edit' : 'Create'}} Project</h2>
+<form [formGroup]="projectEditFormGroup" (ngSubmit)="onSubmit()">
+  <input formControlName="name" />
+  <input formControlName="shortDescription" />
+  <input formControlName="author" />
+  <input type="date" formControlName="creationDate" />
+  <input type="date" formControlName="modifiedDate" />
+  <button type="submit">{{isEditing ? 'Create' : 'Save'}}</button>
+</form>

--- a/modelcabinet.client/src/app/projects/project-edit/project-edit.component.spec.ts
+++ b/modelcabinet.client/src/app/projects/project-edit/project-edit.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProjectEditComponent } from './project-edit.component';
+
+describe('ProjectEditComponent', () => {
+  let component: ProjectEditComponent;
+  let fixture: ComponentFixture<ProjectEditComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ProjectEditComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ProjectEditComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/modelcabinet.client/src/app/projects/project-edit/project-edit.component.ts
+++ b/modelcabinet.client/src/app/projects/project-edit/project-edit.component.ts
@@ -1,0 +1,108 @@
+import { Component, OnInit } from '@angular/core';
+import { FormGroup, FormControl } from '@angular/forms';
+import { Project } from '../../Models/project';
+import { DataService } from '../../data.service';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+
+// https://v17.angular.io/api/forms
+// This component is meant to represent a form that can create or edit an existing project. This task requires completion of Todo #23
+
+// Basic implementation, needs to be reworked
+
+@Component({
+  selector: 'app-project-edit',
+  templateUrl: './project-edit.component.html',
+  styleUrl: './project-edit.component.css'
+})
+
+// Editing an existing project means having to pass in the id of the project most likely
+// Else whenever creating the new project, you pass in the project to the backend
+// Gotta use the service
+
+// Assuming that in the list, the user has the option to click a button to edit on their project
+// They'd pass identification about the project for the ProjectEditComponent to use, most likely an id
+// With creation, there most likely will be a create button somewhere, where there's no identification passed
+export class ProjectEditComponent implements OnInit {
+  projectEditFormGroup: FormGroup = new FormGroup({});
+  isEditing = false;
+
+  // First, try to grab an existing project
+  project: Project = {
+    projectId: -1,
+    name: '',
+    creationDate: new Date,
+    modifiedDate: new Date,
+    description: '',
+    author: '',
+    version: '',
+    assets: { $values: [] },
+    shortDescription: ''
+  };
+
+  constructor(
+    private route: ActivatedRoute,
+    private dataService: DataService,
+    private router: Router) {
+    this.router.events.subscribe(routerevent => {
+      if (routerevent instanceof NavigationEnd) {
+        this.getProjectData();
+      }
+    });
+  }
+
+  ngOnInit(): void {
+    this.initForm();
+  }
+
+  getProjectData(): void {
+    // If project id is -1 or null, which implies there's no project, then create
+    // Whatever the url for creating vs editing is will determine the nature of this
+    this.route.paramMap.subscribe(paramMap => {
+      this.project.projectId = +paramMap.get('id')!;
+    });
+
+    this.isEditing = (this.project.projectId == null || this.project.projectId == -1) ? false : true;
+
+    if (this.isEditing && this.project.projectId != null && this.project.projectId != -1) {
+      this.dataService.getProjectInfoById(this.project.projectId).subscribe((proj: Project) => {
+        this.project = proj;
+
+        // For debugging
+        console.log(
+          `Name: ${this.project.name}\n
+          Description: ${this.project.description}`);
+      },
+        error => console.error('Error fetching Project:', error)
+      );
+    }
+  }
+
+  // Modify the creation dates and modified dates later
+  initForm(): void {
+    this.projectEditFormGroup.patchValue({
+      name: new FormControl(this.project.name),
+      shortDescription: new FormControl(this.project.shortDescription),
+      author: new FormControl(this.project.author),
+
+      creationDate: new FormControl(this.project.creationDate),
+      modifiedDate: new FormControl(this.project.modifiedDate)
+    })
+  }
+
+  // Modify here, pass information back to the backend
+  onSubmit() {
+    console.log("Modify this to update information to the backend");
+    if (this.project == null || !this.projectEditFormGroup.valid)
+      return;
+
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax
+    const updatedProject : Project = { ...this.project, ...this.projectEditFormGroup.value };
+
+    if (this.isEditing && this.project.projectId != null) {
+      this.dataService.updateProjectById(this.project.projectId, updatedProject);
+    }
+    else {
+      this.dataService.createProject(updatedProject);
+    }
+  }
+}


### PR DESCRIPTION
### Modifications
- Added a new `project-edit` component and wrote basic logic for project creation and editing
- Created another `get` function in the service which returns the project object for use in the `project-edit` component
- Added some modules to `app.module.ts`

Thank you for checking to see and see notify if I'm not following your architecture correctly.