### PR TITLE
Rename "About Project" to "About ModelCabinet" in Navbar

### DIFF
--- a/modelcabinet.client/src/app/nav-bar/nav-bar.component.html
+++ b/modelcabinet.client/src/app/nav-bar/nav-bar.component.html
@@ -21,7 +21,7 @@
         <!--Home Link-->
         <li class="nav-item"><a class="nav-link" routerLink="/" routerLinkActive="active">Home</a></li>
         <!--About Project Link-->
-        <li class="nav-item"><a class="nav-link" routerLink="/about-project" routerLinkActive="active">About Project</a></li>
+        <li class="nav-item"><a class="nav-link" routerLink="/about-project" routerLinkActive="active">About ModelCabinet</a></li>
         <!--Projects Link-->
         <li class="nav-item"><a class="nav-link" routerLink="Projects">Projects</a></li>
         <li class="nav-item"><a class="nav-link" routerLink="/changelog">Changelog</a></li>


### PR DESCRIPTION
Updated navbar text from "About Project" to "About ModelCabinet" for clarity.  No functional changes, only a UI text update.