### PR TITLE
Created Interfaces for Login, Register, and User

### DIFF
--- a/modelcabinet.client/src/app/Interfaces/login-dto.ts
+++ b/modelcabinet.client/src/app/Interfaces/login-dto.ts
@@ -1,0 +1,5 @@
+export interface LoginDto {
+  email: string;
+  password: string;
+  rememberMe: boolean;
+}

--- a/modelcabinet.client/src/app/Interfaces/register-dto.ts
+++ b/modelcabinet.client/src/app/Interfaces/register-dto.ts
@@ -1,0 +1,14 @@
+export interface RegisterDto {
+  email: string;
+  password: string;
+  confirmPassword: string;
+  displayName: string;
+  biography?: string;
+  location?: string;
+  website?: string;
+  avatarUrl?: string;
+  twitterHandle?: string;
+  githubUsername?: string;
+  preferredLanguage?: string;
+  timeZone?: string;
+}

--- a/modelcabinet.client/src/app/Interfaces/user-dto.ts
+++ b/modelcabinet.client/src/app/Interfaces/user-dto.ts
@@ -1,0 +1,19 @@
+export interface UserDto {
+  id: string;
+  email: string;
+  displayName: string;
+  biography?: string;
+  location?: string;
+  website?: string;
+  avatarUrl?: string;
+  twitterHandle?: string;
+  githubUsername?: string;
+  preferredLanguage?: string;
+  timeZone?: string;
+  dateJoined: Date;
+  lastActive: Date;
+  isProfilePublic: boolean;
+  emailNotificationsEnabled: boolean;
+  projectUpdatesEnabled: boolean;
+  newMessageNotificationsEnabled: boolean;
+}

--- a/modelcabinet.client/src/app/app.component.ts
+++ b/modelcabinet.client/src/app/app.component.ts
@@ -1,8 +1,16 @@
 import { Component } from '@angular/core';
+import { OnInit } from '@angular/core';
+import { AuthService } from './services/auth.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })
-export class AppComponent {}
+export class AppComponent implements OnInit {
+  constructor(private authService: AuthService) { }
+
+  ngOnInit() {
+    this.authService.loadCurrentUser().subscribe();
+  }
+}

--- a/modelcabinet.client/src/app/services/auth.service.spec.ts
+++ b/modelcabinet.client/src/app/services/auth.service.spec.ts
@@ -1,0 +1,138 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { AuthService } from './auth.service';
+import { LoginDto } from '../Interfaces/login-dto';
+import { UserDto } from '../Interfaces/user-dto';
+import { RegisterDto } from '../Interfaces/register-dto';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+
+  // Mock response data (UserDto)
+  const mockUserResponse: UserDto = {
+    id: '1',
+    email: 'test@example.com',
+    displayName: 'Test User',
+    biography: 'Test bio',
+    location: 'Test location',
+    website: 'http://test.com',
+    avatarUrl: 'http://test.com/avatar.jpg',
+    twitterHandle: 'testuser',
+    githubUsername: 'testuser',
+    preferredLanguage: 'en',
+    timeZone: 'UTC',
+    dateJoined: new Date(),
+    lastActive: new Date(),
+    isProfilePublic: true,
+    emailNotificationsEnabled: true,
+    projectUpdatesEnabled: true,
+    newMessageNotificationsEnabled: true
+  };
+
+  // Mock login request data (LoginDto)
+  const mockLoginRequest: LoginDto = {
+    email: 'test@example.com',
+    password: 'testPassword123!',
+    rememberMe: true
+  };
+
+  // Mock register request data (RegisterDto)
+  const mockRegisterRequest: RegisterDto = {
+    email: 'test@example.com',
+    password: 'testPassword123!',
+    confirmPassword: 'testPassword123!',
+    displayName: 'Test User'
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AuthService]
+    });
+
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('login', () => {
+    it('should authenticate user and update current user subject', () => {
+      service.login(mockLoginRequest).subscribe(user => {
+        expect(user).toEqual(mockUserResponse);
+        expect(service.currentUser).toEqual(mockUserResponse);
+      });
+
+      const loginReq = httpMock.expectOne('/api/auth/login');
+      expect(loginReq.request.method).toBe('POST');
+      loginReq.flush(mockUserResponse);
+    });
+  });
+
+  describe('register', () => {
+    it('should register user and update current user subject', () => {
+      service.register(mockRegisterRequest).subscribe(user => {
+        expect(user).toEqual(mockUserResponse);
+        expect(service.currentUser).toEqual(mockUserResponse);
+      });
+
+      const registerReq = httpMock.expectOne('/api/auth/register');
+      expect(registerReq.request.method).toBe('POST');
+      registerReq.flush(mockUserResponse);
+    });
+  });
+
+  describe('logout', () => {
+    it('should clear current user on logout', () => {
+      service.logout().subscribe(() => {
+        expect(service.currentUser).toBeNull();
+      });
+
+      const logoutReq = httpMock.expectOne('/api/auth/logout');
+      expect(logoutReq.request.method).toBe('POST');
+      logoutReq.flush({ message: 'Logged out successfully' });
+    });
+  });
+
+  describe('loadCurrentUser', () => {
+    it('should load current user successfully', () => {
+      service.loadCurrentUser().subscribe(user => {
+        expect(user).toEqual(mockUserResponse);
+        expect(service.currentUser).toEqual(mockUserResponse);
+      });
+
+      const req = httpMock.expectOne('/api/auth/current');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockUserResponse);
+    });
+
+    it('should handle error and set current user to null', () => {
+      service.loadCurrentUser().subscribe(user => {
+        expect(user).toBeNull();
+        expect(service.currentUser).toBeNull();
+      });
+
+      const req = httpMock.expectOne('/api/auth/current');
+      req.error(new ErrorEvent('Network error'));
+    });
+  });
+
+  describe('isAuthenticated', () => {
+    it('should return true when user is logged in', () => {
+      service['currentUserSubject'].next(mockUserResponse);
+      expect(service.isAuthenticated()).toBeTrue();
+    });
+
+    it('should return false when no user is logged in', () => {
+      service['currentUserSubject'].next(null);
+      expect(service.isAuthenticated()).toBeFalse();
+    });
+  });
+});

--- a/modelcabinet.client/src/app/services/auth.service.ts
+++ b/modelcabinet.client/src/app/services/auth.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, tap, catchError, of } from 'rxjs';
+import { LoginDto } from '../Interfaces/login-dto';
+import { UserDto } from '../Interfaces/user-dto';
+import { RegisterDto } from '../Interfaces/register-dto';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthService {
+  private currentUserSubject = new BehaviorSubject<UserDto | null>(null);
+  public currentUser$ = this.currentUserSubject.asObservable();
+
+  constructor(private http: HttpClient) {}
+
+  login(credentials: LoginDto): Observable<UserDto> {
+    return this.http.post<UserDto>('/api/auth/login', credentials).pipe(
+      tap(user => {
+        this.currentUserSubject.next(user);
+      })
+    );
+  }
+
+  register(userData: RegisterDto): Observable<UserDto> {
+    return this.http.post<UserDto>('/api/auth/register', userData).pipe(
+      tap(user => {
+        this.currentUserSubject.next(user);
+      })
+    );
+  }
+
+  logout(): Observable<void> {
+    return this.http.post<void>('/api/auth/logout', {}).pipe(
+      tap(() => {
+        this.currentUserSubject.next(null);
+      })
+    );
+  }
+
+  public loadCurrentUser(): Observable<UserDto | null> {
+    return this.http.get<UserDto>('/api/auth/current').pipe(
+      tap(user => {
+        this.currentUserSubject.next(user);
+      }),
+      catchError(() => {
+        this.currentUserSubject.next(null);
+        return of(null);
+      })
+    );
+  }
+
+  get currentUser(): UserDto | null {
+    return this.currentUserSubject.value;
+  }
+
+  isAuthenticated(): boolean {
+    return !!this.currentUserSubject.value;
+  }
+}


### PR DESCRIPTION
# Add TypeScript interfaces for authentication DTOs

## Changes
- Created new TypeScript interfaces (`LoginDto`, `RegisterDto`, `UserDto`) to match backend DTO models

## Purpose
These interfaces provide type definitions for authentication-related data transfer objects, ensuring type safety between frontend and backend communication. They mirror the C# DTO models exactly, helping catch potential mismatches during development.


## Related
Implements frontend types for:
- LoginDto.cs
- RegisterDto.cs
- UserDto.cs