### PR TITLE
Fix: Corrected test file for TagLabelComponent

### DIFF
--- a/modelcabinet.client/src/app/tags/tag-label/tag-label.component.spec.ts
+++ b/modelcabinet.client/src/app/tags/tag-label/tag-label.component.spec.ts
@@ -20,7 +20,7 @@ describe('TagLabelComponent', () => {
       tagName: 'Testing',
       color: 'fc7f7f'
     }
-    component.tag = tagData;
+    component.tagLabel = tagData;
 
     fixture.detectChanges();
   });


### PR DESCRIPTION
Fixed the test file for TagLabelComponent. Updated the test to use `tagLabel` instead of `tag` to match the component's @Input property. Tests now pass successfully.
