### PR TITLE
Fix: TagEditComponent test setup

### DIFF
--- a/modelcabinet.client/src/app/tags/tag-edit/tag-edit.component.spec.ts
+++ b/modelcabinet.client/src/app/tags/tag-edit/tag-edit.component.spec.ts
@@ -1,14 +1,33 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { TagEditComponent } from './tag-edit.component';
+import { DataService } from '../../data.service';
+import { of } from 'rxjs';
+import { ReactiveFormsModule } from '@angular/forms';
 
 describe('TagEditComponent', () => {
   let component: TagEditComponent;
   let fixture: ComponentFixture<TagEditComponent>;
+  let mockDataService: jasmine.SpyObj<DataService>;
+
 
   beforeEach(async () => {
+    // Create a mock DataService with spies
+    mockDataService = jasmine.createSpyObj('DataService', [
+      'getAllTags',
+      'updateTag',
+      'createTag',
+      'deleteTag'
+    ]);
+
+    // Ensure `tags$` is properly mocked as an observable
+    Object.defineProperty(mockDataService, 'tags$', { get: () => of([]) });
+
     await TestBed.configureTestingModule({
-      declarations: [TagEditComponent]
+      imports: [ReactiveFormsModule], // Required for FormGroup and FormControl
+      declarations: [TagEditComponent],
+      providers: [
+        { provide: DataService, useValue: mockDataService } // Provide Mocking DataService
+      ]
     })
     .compileComponents();
 

--- a/modelcabinet.client/src/app/tags/tag-label/tag-label.component.spec.ts
+++ b/modelcabinet.client/src/app/tags/tag-label/tag-label.component.spec.ts
@@ -20,7 +20,7 @@ describe('TagLabelComponent', () => {
       tagName: 'Testing',
       color: 'fc7f7f'
     }
-    component.tag = tagData;
+    component.tagLabel = tagData;
 
     fixture.detectChanges();
   });


### PR DESCRIPTION
Fixed the test for TagEditComponent. Set up a mock for DataService. The test now runs without HttpClient errors.