### PR TITLE
Implemented Auth Guards for Route Protection

### DIFF
--- a/modelcabinet.client/src/app/app-routing.module.ts
+++ b/modelcabinet.client/src/app/app-routing.module.ts
@@ -14,24 +14,28 @@ import { TagEditComponent } from './tags/tag-edit/tag-edit.component';
 import { LoginComponent } from './login/login.component';
 import { RegisterComponent } from './register/register.component';
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
+import { authGuard } from './guards/auth.guard';
+import { nonAuthGuard } from './guards/non-auth.guard';
 
 // TODO: Change Names to actual Module Names
 const routes: Routes = [
   { path: '', pathMatch: "full", component: LandingPageComponent },
   { path: 'LandingPage', redirectTo: '' },
-  { path: 'Projects', component: ProjectListPageComponent },
-  { path: 'Projects/:id', component: ProjectPageComponent },
+  { path: 'Projects', component: ProjectListPageComponent, canActivate: [authGuard] },
+  { path: 'Projects/:id', component: ProjectPageComponent, canActivate: [authGuard] },
   { path: 'About-ModelCabinet', component: AboutModelCabinetComponent },
   { path: 'changelog', component: ChangelogComponent },
-  { path: `assets`, component: AssetListComponent },
+  { path: `assets`, component: AssetListComponent, canActivate: [authGuard] },
   { path: 'Help', component: HelpProjectComponent },
-  { path: 'Assets', component: AssetListComponent },
-  { path: 'Assets/:id', component: AssetDetailComponent},
-  { path: 'User', component: ProfilePageComponent },
+  { path: 'Assets', component: AssetListComponent, canActivate: [authGuard] },
+  { path: 'Assets/:id', component: AssetDetailComponent, canActivate: [authGuard] },
+  { path: 'User', component: ProfilePageComponent, canActivate: [authGuard] },
   { path: 'coming-soon', component: ComingSoonComponent },
-  { path: 'Edit-Tags', component:TagEditComponent },
-  { path: 'Login', component: LoginComponent },
-  { path: 'Register', component: RegisterComponent },
+  { path: 'Edit-Tags', component: TagEditComponent, canActivate: [authGuard] },
+  { path: 'login', component: LoginComponent, canActivate: [nonAuthGuard] },
+  { path: 'Login', component: LoginComponent, canActivate: [nonAuthGuard] }, // duplicated for case insensitivity
+  { path: 'register', component: RegisterComponent, canActivate: [nonAuthGuard] },
+  { path: 'Register', component: RegisterComponent, canActivate: [nonAuthGuard] }, // duplicated for case insensitivity
   { path: '**', component: PageNotFoundComponent }
 ];
 

--- a/modelcabinet.client/src/app/guards/auth.guard.spec.ts
+++ b/modelcabinet.client/src/app/guards/auth.guard.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Router, UrlTree, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { authGuard } from './auth.guard';
+import { AuthService } from '../services/auth.service';
+
+describe('authGuard', () => {
+  let authService: jasmine.SpyObj<AuthService>;
+  let router: Router;
+  let dummyRoute: ActivatedRouteSnapshot;
+  let dummyState: RouterStateSnapshot;
+
+  beforeEach(() => {
+    authService = jasmine.createSpyObj('AuthService', ['isAuthenticated']);
+    dummyRoute = {} as ActivatedRouteSnapshot;
+    dummyState = { url: '/projects' } as RouterStateSnapshot;
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [
+        { provide: AuthService, useValue: authService }
+      ]
+    });
+
+    router = TestBed.inject(Router);
+    spyOn(router, 'createUrlTree').and.callThrough();
+  });
+
+  it('should allow access when user is authenticated', () => {
+    authService.isAuthenticated.and.returnValue(true);
+
+    const result = TestBed.runInInjectionContext(() => authGuard(dummyRoute, dummyState));
+
+    expect(result).toBe(true);
+    expect(authService.isAuthenticated).toHaveBeenCalled();
+    expect(router.createUrlTree).not.toHaveBeenCalled();
+  });
+
+  it('should redirect to login when user is not authenticated', () => {
+    authService.isAuthenticated.and.returnValue(false);
+    const mockUrlTree = {} as UrlTree;
+    (router.createUrlTree as jasmine.Spy).and.returnValue(mockUrlTree);
+
+    const result = TestBed.runInInjectionContext(() => authGuard(dummyRoute, dummyState));
+
+    expect(result).toBe(mockUrlTree);
+    expect(authService.isAuthenticated).toHaveBeenCalled();
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/login']);
+  });
+});

--- a/modelcabinet.client/src/app/guards/auth.guard.ts
+++ b/modelcabinet.client/src/app/guards/auth.guard.ts
@@ -1,0 +1,18 @@
+import { inject } from '@angular/core';
+import { Router, CanActivateFn, UrlTree, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = (
+  route: ActivatedRouteSnapshot,
+  state: RouterStateSnapshot
+): boolean | UrlTree => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+
+  // Redirect to login page if not authenticated
+  return router.createUrlTree(['/login']);
+};

--- a/modelcabinet.client/src/app/guards/non-auth.guard.spec.ts
+++ b/modelcabinet.client/src/app/guards/non-auth.guard.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Router, UrlTree, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { nonAuthGuard } from './non-auth.guard';
+import { AuthService } from '../services/auth.service';
+
+describe('nonAuthGuard', () => {
+  let authService: jasmine.SpyObj<AuthService>;
+  let router: Router;
+  let dummyRoute: ActivatedRouteSnapshot;
+  let dummyState: RouterStateSnapshot;
+
+  beforeEach(() => {
+    authService = jasmine.createSpyObj('AuthService', ['isAuthenticated']);
+    dummyRoute = {} as ActivatedRouteSnapshot;
+    dummyState = { url: '/login' } as RouterStateSnapshot;
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [
+        { provide: AuthService, useValue: authService }
+      ]
+    });
+
+    router = TestBed.inject(Router);
+    spyOn(router, 'createUrlTree').and.callThrough();
+  });
+
+  it('should allow access when user is not authenticated', () => {
+    authService.isAuthenticated.and.returnValue(false);
+
+    const result = TestBed.runInInjectionContext(() => nonAuthGuard(dummyRoute, dummyState));
+
+    expect(result).toBe(true);
+    expect(authService.isAuthenticated).toHaveBeenCalled();
+    expect(router.createUrlTree).not.toHaveBeenCalled();
+  });
+
+  it('should redirect to home when user is authenticated', () => {
+    authService.isAuthenticated.and.returnValue(true);
+    const mockUrlTree = {} as UrlTree;
+    (router.createUrlTree as jasmine.Spy).and.returnValue(mockUrlTree);
+
+    const result = TestBed.runInInjectionContext(() => nonAuthGuard(dummyRoute, dummyState));
+
+    expect(result).toBe(mockUrlTree);
+    expect(authService.isAuthenticated).toHaveBeenCalled();
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/']);
+  });
+});

--- a/modelcabinet.client/src/app/guards/non-auth.guard.ts
+++ b/modelcabinet.client/src/app/guards/non-auth.guard.ts
@@ -1,0 +1,18 @@
+import { inject } from '@angular/core';
+import { Router, CanActivateFn, UrlTree, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const nonAuthGuard: CanActivateFn = (
+  route: ActivatedRouteSnapshot,
+  state: RouterStateSnapshot
+): boolean | UrlTree => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (!authService.isAuthenticated()) {
+    return true;
+  }
+
+  // Redirect to home page if already authenticated
+  return router.createUrlTree(['/']);
+};

--- a/modelcabinet.client/src/app/landing-page/landing-page.component.html
+++ b/modelcabinet.client/src/app/landing-page/landing-page.component.html
@@ -12,7 +12,7 @@
   <!-- Call to Action Section -->
   <div class="mt-5">
     <p class="text-muted mb-3">Ready to streamline your 3D model management?</p>
-    <button class="btn btn-success btn-lg" routerLink="/Register">Sign Up Now</button>
+    <button class="btn btn-success btn-lg" routerLink="/register">Sign Up Now</button>
   </div>
 
   <!-- Features Section -->


### PR DESCRIPTION
## Description
Route guards are implemented to protect routes based on authentication status. Two guards have been added:
- authGuard: Prevents unauthenticated users from accessing protected routes
- nonAuthGuard: Prevents authenticated users from accessing login/register pages

### Changes
- Created route guards using CanActivateFn
- Applied guards to appropriate routes in the routing module
- Added comprehensive test coverage for both guards
- Added duplicate routes for login/register to accommodate Login/Register

### Protected Routes
The following routes now require authentication:
-Projects and project details
-Assets and asset details
-User profile
-Tag editing

### Note
No UI changes to the navbar have been made regarding authentication as this is being worked on in a separate ticket.