### PR TITLE
Fix Authentication Persistance After Logout

### DIFF
--- a/modelcabinet.client/src/app/nav-bar/nav-bar.component.ts
+++ b/modelcabinet.client/src/app/nav-bar/nav-bar.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
+import { finalize } from 'rxjs/operators';
 
 
 @Component({
@@ -9,6 +10,8 @@ import { Router } from '@angular/router';
   styleUrls: ['./nav-bar.component.css']
 })
 export class NavBarComponent {
+  isLoggingOut = false;
+
   constructor(private authService: AuthService, private router: Router) { }
 
   isAuthenticated(): boolean {
@@ -16,8 +19,22 @@ export class NavBarComponent {
   }
 
   logout(): void {
-    this.authService.logout();
-    // redirect to homepage
-    this.router.navigate(['/']);
+    console.log('Logout process initiated');
+    this.isLoggingOut = true;
+
+    this.authService.logout().pipe(
+      finalize(() => this.isLoggingOut = false)
+    ).subscribe({
+      next: () => {
+        // redirect to homepage
+        this.router.navigate(['/']);
+      },
+      error: (error) => {
+        console.error('Logout error:', error);
+        // if error, redirect anyway
+        this.router.navigate(['/']);
+      }
+    })
+
   }
 }

--- a/modelcabinet.client/src/app/projects/project-page/project-page.component.spec.ts
+++ b/modelcabinet.client/src/app/projects/project-page/project-page.component.spec.ts
@@ -17,16 +17,17 @@ describe('ProjectPageComponent', () => {
   let fixture: ComponentFixture<ProjectPageComponent>;
 
   const mockProject: Project = {
-    projectId: 1,
-    name: 'Test Project',
-    creationDate: new Date(),
-    modifiedDate: new Date(),
-    description: 'Test description',
-    author: 'Author name',
-    version: '1.0',
-    assets: [],
-    shortDescription: 'Short description',
-    slug: 'test-project',
+      projectId: 1,
+      name: 'Test Project',
+      creationDate: new Date(),
+      modifiedDate: new Date(),
+      description: 'Test description',
+      author: 'Author name',
+      version: '1.0',
+      assets: [],
+      shortDescription: 'Short description',
+      slug: 'test-project',
+      projectTags: []
   };
 
   let mockDataService;
@@ -57,7 +58,7 @@ describe('ProjectPageComponent', () => {
 
     fixture = TestBed.createComponent(ProjectPageComponent);
     component = fixture.componentInstance;
-    component.project = new BehaviorSubject<Project>(mockProject);
+    component.project$ = new BehaviorSubject<Project>(mockProject);
     fixture.detectChanges();
   });
 


### PR DESCRIPTION
## Issue
Users were able to access protected areas after logging out. This occurred because authentication cookies were not being properly cleared during the logout process.

### Root Cause
The logout() method in NavBarComponent was calling authService.Logout() but wasn't subscribing to the Observable that this method returns. This meant that the request to the API logout might not be completed before navigating away.

### Solution
Update the NavBarComponent to subscibe to the Observable returned by authService.